### PR TITLE
Handle any `ModelError` raised by replicate

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -29,6 +29,7 @@ async def dream(ctx, *, prompt):
         else: # something else went wrong, log to console so developer can debug
             print(ex)
             await msg.edit(content="> Error. Please try again.")
+        return # return early upon failure
     await msg.edit(content=f"“{prompt}”\n{image}")
 
 

--- a/bot.py
+++ b/bot.py
@@ -20,10 +20,15 @@ bot = commands.Bot(
 async def dream(ctx, *, prompt):
     """Generate an image from a text prompt using the stable-diffusion model"""
     msg = await ctx.send(f"“{prompt}”\n> Generating...")
-
     model = replicate.models.get("stability-ai/stable-diffusion")
-    image = model.predict(prompt=prompt)[0]
-
+    try:
+        image = model.predict(prompt=prompt)[0]
+    except replicate.exceptions.ModelError as ex:
+        if "NSFW" in str(ex): # model output was classified as NSFW
+            await msg.edit(content="> NSFW detected. Please try again.")
+        else: # something else went wrong, log to console so developer can debug
+            print(ex)
+            await msg.edit(content="> Error. Please try again.")
     await msg.edit(content=f"“{prompt}”\n{image}")
 
 


### PR DESCRIPTION
@zeke Have been using this code a for a custom bot actually. Super handy for testing models. I notice we don't handle any errors raised by the replicate package. This presently happens when we flag an NSFW output, but can happen for other reasons too.

It's unfortunately not nearly as clean - and tutorial code should probably be clean and simple. Any ideas? 